### PR TITLE
Switch logical conditions to use 'is'

### DIFF
--- a/s3-encryption/deploy-bot.py
+++ b/s3-encryption/deploy-bot.py
@@ -37,7 +37,7 @@ Examples:
 from docopt import docopt
 args = docopt(__doc__)
 
-if args['-h']==True or args['--help']==True:
+if args['-h'] is True or args['--help'] is True:
     print(__doc__)
 
 import boto3
@@ -47,6 +47,7 @@ import datetime
 import time
 import subprocess
 import os
+
 
 def load_file(filename, purpose):
 	try:
@@ -63,6 +64,7 @@ def load_file(filename, purpose):
 		else:
 			file.close()
 			return value
+
 
 def validate_file(filename):
 	try:
@@ -87,7 +89,7 @@ possible_environment_variables = [
 	"S3_INVENTORY_VERSIONING", #Required, "Current" | "All"
 ]
 
-if args['set-env-var'] == True:
+if args['set-env-var'] is True:
 	lambda_env_var = load_file('lambda-env-variables.txt', 'Lambda Environment Variables')
 
 	print('Lambda environment variables were: ')
@@ -133,7 +135,7 @@ if args['set-env-var'] == True:
 
 	ABORT = True
 
-if args['deploy'] == True:
+if args['deploy'] is True:
 	ABORT = False
 
 	if args['--accounts']:
@@ -148,7 +150,7 @@ if args['deploy'] == True:
 	# Shared variables
 	name = args['<botname>']   # 's3_bucket_configuration_audit_bot'
 
-	if args['--multiregion']==True:
+	if args['--multiregion'] is True:
 		multiregion = True
 	else:
 		multiregion = False
@@ -201,6 +203,7 @@ if args['deploy'] == True:
 		if lambda_environment_variables['Variables'][key] == 'string':
 			lambda_environment_variables['Variables'].pop(key, None)
 
+
 def create_iam_role():
 	if role_policy:
 		try:
@@ -233,6 +236,7 @@ def create_iam_role():
 		else:
 			print('Updated policy for IAM role in account ' + account)
 
+
 def create_lambda_function():
 	try:
 		response = aws_lambda.create_function(
@@ -254,6 +258,7 @@ def create_lambda_function():
 			print(e)
 	else:
 		print('Created lambda function in region ' + region + ' in account ' + account + ', ARN: ' + response['FunctionArn'])
+
 
 def update_lambda_function():
 	# Try to update code:
@@ -297,6 +302,7 @@ def update_lambda_function():
 	else:
 		print('Updated lambda function permissions for in region ' + region + ' in account ' + account + ' to allow CloudWatch triggers')
 
+
 def create_cloudwatch_targets():
 	try:
 		targets = cw.put_targets(
@@ -313,6 +319,7 @@ def create_cloudwatch_targets():
 	else:
 		print('Updated target lambda for cloudwatch rule ' + name + ' in region ' + region + ' in account ' + account)
 
+
 def create_cloudwatch_rule():
 	try:
 		new_rule = cw.put_rule(
@@ -328,7 +335,8 @@ def create_cloudwatch_rule():
 		print('Updated cloudwatch rule in region ' + region + ' in account ' + account + ', rule ARN = ' + new_rule['RuleArn'])
 		create_cloudwatch_targets()
 
-if ABORT == False: # If everything looks good, try to deploy #
+
+if ABORT is False: # If everything looks good, try to deploy #
 	for account in accounts:
 		session = boto3.session.Session(profile_name=account) #set profile per account
 		iam = session.client('iam')
@@ -340,7 +348,7 @@ if ABORT == False: # If everything looks good, try to deploy #
 		if 'S3_INVENTORY_ACCOUNT' not in lambda_environment_variables['Variables']:
 			lambda_environment_variables['Variables']['S3_INVENTORY_ACCOUNT'] = account_num
 
-		if multiregion == True:
+		if multiregion is True:
 			regions = boto3.session.Session(profile_name=account).client('ec2').describe_regions()
 		else:
 			regions = {'Regions':[{'RegionName':region}]}
@@ -359,4 +367,3 @@ if ABORT == False: # If everything looks good, try to deploy #
 			# Create CloudWatch Rules
 			cw = session.client('events')		
 			create_cloudwatch_rule()
-

--- a/s3-encryption/s3-bucket-configuration-bot.py
+++ b/s3-encryption/s3-bucket-configuration-bot.py
@@ -8,13 +8,13 @@ accountnum = boto3.client('sts').get_caller_identity()['Account']
 account = boto3.client('iam').list_account_aliases()['AccountAliases'][0]
 
 if 'SLACK_WEBHOOK' in os.environ:
-    SLACK=True
-    slack_url = os.environ['SLACK_WEBHOOK']               
-    slack_channel = os.environ['SLACK_CHANNEL']           
+    SLACK = True
+    slack_url = os.environ['SLACK_WEBHOOK']
+    slack_channel = os.environ['SLACK_CHANNEL']
 else:
-    SLACK=False
+    SLACK = False
 
-if 'DEFAULT_ENCRYPTION_KMS' in os.environ: 
+if 'DEFAULT_ENCRYPTION_KMS' in os.environ:
     target_encryption = {
         'Rules': [
             {
@@ -71,6 +71,7 @@ monitored_events = [
 message = ''
 message_attachment = {}
 
+
 def check_default_encryption(bucketname):
     global message
     try:
@@ -94,7 +95,8 @@ def check_default_encryption(bucketname):
                 message += ', but it does not match the target encryption policy this bot enforces of ' + json.dumps(target_encryption['Rules'][0]['ApplyServerSideEncryptionByDefault']) + ', please investigate.'
                 return True
         else:
-            return False      
+            return False
+
 
 def apply_default_encryption(bucketname):
     global message
@@ -113,6 +115,7 @@ def apply_default_encryption(bucketname):
     else:
         message += 'Default encryption policy ' + json.dumps(target_encryption['Rules'][0]['ApplyServerSideEncryptionByDefault']) + ' added to bucket\n'
 
+
 def check_for_s3_inventory(bucketname, target_policy):
     global message
     try:
@@ -127,6 +130,7 @@ def check_for_s3_inventory(bucketname, target_policy):
                     return True
         return False
 
+
 def apply_s3_inventory(bucketname, target_policy):
     global message
     try:
@@ -136,6 +140,7 @@ def apply_s3_inventory(bucketname, target_policy):
         print(e)
     else:
         message += 'S3 Inventory Policy added to bucket, delivering inventory reports to ' + target_policy['InventoryConfiguration']['Destination']['S3BucketDestination']['Bucket'] + '\n'
+
 
 def check_bucket_policy_statement_public(statement):
     global message
@@ -150,6 +155,7 @@ def check_bucket_policy_statement_public(statement):
         else:
             return True                 
     return False
+
 
 def check_bucket_policy(bucketname):
     global message
@@ -170,13 +176,14 @@ def check_bucket_policy(bucketname):
                 message += 'Warning! Bucket allows public access via bucket policy.\n'
         return bucket_policy
 
+
 def check_bucket_ACL_public(bucketname):
     global message
     try:
         bucket_acl = s3.get_bucket_acl(Bucket=bucketname)
     except Exception as e:
         print(e)
-    else:   
+    else:
         bucket_acl_public = []
         if bucket_acl:
             for grant in bucket_acl["Grants"]:
@@ -185,11 +192,12 @@ def check_bucket_ACL_public(bucketname):
                     bucket_acl_public.append(grant)
         return bucket_acl_public
 
+
 def handler(event, context):
     global message
     global message_attachment
     print(json.dumps(event))
-    
+
     if 'detail' in event:
         eventName = event['detail']['eventName']
         bucketname = event['detail']['requestParameters']['bucketName']
@@ -275,9 +283,9 @@ def handler(event, context):
 
                 print(message)
 
-                if SLACK==True:
+                if SLACK is True:
                     slack_message = {
-                        'text' : message,
+                        'text': message,
                         'mrkdwn': True,
                         'channel': slack_channel,
                         'username': 'S3 Bucket Configuration Audit Bot',
@@ -307,4 +315,3 @@ def handler(event, context):
                           print('Error!  Failed to alert slack channel: %d %s', exc.code, exc.reason)
                         except URLError as exc:
                           print('Error!  Failed to alert slack channel.  Server connection failed: %s', exc.reason)
-

--- a/s3-encryption/s3-bucket-default-encryption.py
+++ b/s3-encryption/s3-bucket-default-encryption.py
@@ -31,13 +31,13 @@ import json
 import datetime
 import os
 
-if args['-h']==True or args['--help']==True:
+if args['-h'] is True or args['--help'] is True:
     print(__doc__)
 
 ABORT = False
-if args['audit']==True:
+if args['audit'] is True:
     mode = 'audit'
-elif args['apply']==True:
+elif args['apply'] is True:
     mode = 'apply'
 else:
     print('No mode specified')
@@ -57,12 +57,12 @@ if args['<bucket_names>']:
 else:
     target_buckets = []
 
-if args['--filename']!=None:
+if args['--filename'] is not None:
     filename = args['--filename']
 else:
     filename = ''
 
-if args['--kms']!=None:
+if args['--kms'] is not None:
     target_encryption = {
         'Rules': [
             {
@@ -84,6 +84,7 @@ else:
         ]
     }
 
+
 def load_file(filename, purpose):
     try:
         file = open(filename, 'r')
@@ -100,6 +101,7 @@ def load_file(filename, purpose):
             file.close()
             return value
 
+
 if mode=='apply':
     lambda_env_var = load_file('lambda-env-variables.txt', 'Lambda Env Variables')
     if args['--kms']!=None:
@@ -108,10 +110,12 @@ if mode=='apply':
     lamba_env_var_file.write(json.dumps(lambda_env_var,indent=4,separators=(',', ': ')))
     lamba_env_var_file.close()
 
+
 def json_serial(obj):
     """JSON serializer for objects not serializable by default json code"""
     if isinstance(obj, (datetime.datetime, datetime.date)):
         return obj.isoformat()
+
 
 def check_default_encryption(account, bucket):
     try:
@@ -134,6 +138,7 @@ def check_default_encryption(account, bucket):
         else:
             return False
 
+
 def fix_default_encryption(account, bucket):
     try:
         s3.put_bucket_encryption(
@@ -153,7 +158,7 @@ def fix_default_encryption(account, bucket):
 
 s3_default_encryption = {}
 
-if ABORT==False:
+if ABORT is False:
     for account in accounts:
         session = boto3.session.Session(profile_name=account) #set profile per account
         s3 = session.client('s3')
@@ -171,19 +176,19 @@ if ABORT==False:
                 if not target_buckets or bucket['Name'] in target_buckets:
                     s3_default_encryption[account]['Buckets'].append({'Bucket':bucket['Name'],'DefaultEncryption':[]})
                     current_policy = check_default_encryption(account, bucket)
-                    if current_policy == False:
+                    if current_policy is False:
                         if mode == 'audit':
                             print(account + ' ' + bucket['Name'] + ' does NOT have any default encryption policy')
                         if mode == 'apply':
-                            if fix_default_encryption(account, bucket) == True:
+                            if fix_default_encryption(account, bucket) is True:
                                 s3_default_encryption[account]['Buckets'][bucket_count]['DefaultEncryption'] = target_encryption['Rules'][0]['ApplyServerSideEncryptionByDefault']
-                    elif current_policy == True:
+                    elif current_policy is True:
                         print(account + ' ' + bucket['Name'] + ' already has the target default encryption policy')
                         s3_default_encryption[account]['Buckets'][bucket_count]['DefaultEncryption'] = target_encryption['Rules'][0]['ApplyServerSideEncryptionByDefault']
                     else:
                         print(account + ' ' + bucket['Name'] + ' already has a default encryption policy of ' + json.dumps(current_policy) + ' but that does not match target policy ' + json.dumps(target_encryption['Rules'][0]['ApplyServerSideEncryptionByDefault']))
-                        if mode == 'apply' and args['--force'] == True:
-                            if fix_default_encryption(account, bucket) == True:
+                        if mode == 'apply' and args['--force'] is True:
+                            if fix_default_encryption(account, bucket) is True:
                                     s3_default_encryption[account]['Buckets'][bucket_count]['DefaultEncryption'] = target_encryption['Rules'][0]['ApplyServerSideEncryptionByDefault']
                             else:
                                 s3_default_encryption[account]['Buckets'][bucket_count]['DefaultEncryption'] = current_policy

--- a/s3-encryption/s3-bucket-inventory-policy.py
+++ b/s3-encryption/s3-bucket-inventory-policy.py
@@ -36,13 +36,13 @@ import json
 import datetime
 import os
 
-if args['-h']==True or args['--help']==True:
+if args['-h'] is True or args['--help'] is True:
 	print(__doc__)
 
 ABORT = False
-if args['audit']==True:
+if args['audit'] is True:
     mode = 'audit'
-elif args['apply']==True:
+elif args['apply'] is True:
     mode = 'apply'
 else:
     print('No mode specified')
@@ -64,7 +64,7 @@ else:
 
 if args['<frequency>'] not in ['Weekly','Daily']:
 	print('Invalid frequency, must be Weekly or Daily')
-	ABORT=True
+	ABORT = True
 
 target_policy = {
 	'Id': args['<inventory_rule_name>'],
@@ -87,12 +87,11 @@ target_policy = {
 	}
 }
 
-if args['--allversions']==True:
+if args['--allversions'] is True:
 	target_policy['InventoryConfiguration']['IncludedObjectVersions'] = 'All'
 
 if args['--format'] is not None and args['--format'] in ['ORC', 'CSV']:
 	target_policy['InventoryConfiguration']['Destination']['S3BucketDestination']['Format'] = args['--format']
-
 
 
 def load_file(filename, purpose):
@@ -117,7 +116,7 @@ if mode == 'apply':
 	lambda_env_var['Variables']['S3_INVENTORY_RULE_NAME'] = args['<inventory_rule_name>']
 	lambda_env_var['Variables']['S3_INVENTORY_BUCKET_PREFIX'] = args['<inventory_buckets_prefix>']
 
-	if args['--allversions']==True:
+	if args['--allversions'] is True:
 		lambda_env_var['Variables']['S3_INVENTORY_VERSIONING'] = 'All'
 	else:
 		lambda_env_var['Variables']['S3_INVENTORY_VERSIONING'] = 'Current'
@@ -134,6 +133,7 @@ if mode == 'apply':
 	lamba_env_var_file.write(json.dumps(lambda_env_var,indent=4,separators=(',', ': ')))
 	lamba_env_var_file.close()
 
+
 def check_for_s3_inventory():
 	try:
 		inventories = s3.list_bucket_inventory_configurations(
@@ -149,6 +149,7 @@ def check_for_s3_inventory():
 					return True
 	return False
 
+
 def apply_s3_inventory():
 	try:
 		response = s3.put_bucket_inventory_configuration(**target_policy)
@@ -162,7 +163,7 @@ def apply_s3_inventory():
 
 inventories = {}
 
-if ABORT == False:
+if ABORT is False:
 	for account in accounts:
 		session = boto3.session.Session(profile_name=account)
 		s3 = session.client('s3')


### PR DESCRIPTION
Hey @tombachmann ! I was looking through the code on this project tonight to learn more about what it does, and noticed a few small things.

In this PR, I followed [PEP's guidance](https://docs.quantifiedcode.com/python-anti-patterns/readability/comparison_to_true.html) and changed comparisons of the form `something == True` to `something is True`.  This is a minor thing, but it can help you catch cases where you expected something to be a `bool` and it wasn't one. For example:

![image](https://user-images.githubusercontent.com/7608904/36942679-937ce996-1f3e-11e8-918e-512f4d3f4695.png)

Please consider this PR to change your strategy for logical conditions.