### PR TITLE
Use 'default' if AWS_PROFILE is unset

### DIFF
--- a/s3-encryption/deploy-bot.py
+++ b/s3-encryption/deploy-bot.py
@@ -141,11 +141,10 @@ if args['deploy'] is True:
 	if args['--accounts']:
 	    accounts = args['--accounts'].split(',')
 	else:
-	    if 'AWS_PROFILE' in os.environ:
-	        accounts = os.environ['AWS_PROFILE'].split(',')
-	    else:
-	        print('You did not specify --accounts and also do not have AWS_PROFILE exported to environmental variables')
-	        ABORT = True
+	    try:
+		accounts = os.environ['AWS_PROFILE'].split(',')
+	    except KeyError:
+		accounts = ['default']
 
 	# Shared variables
 	name = args['<botname>']   # 's3_bucket_configuration_audit_bot'

--- a/s3-encryption/s3-bucket-default-encryption.py
+++ b/s3-encryption/s3-bucket-default-encryption.py
@@ -46,11 +46,10 @@ else:
 if args['--accounts']:
     accounts = args['--accounts'].split(',')
 else:
-    if 'AWS_PROFILE' in os.environ:
-        accounts = os.environ['AWS_PROFILE'].split(',')
-    else:
-        print('You did not specify --accounts and also do not have AWS_PROFILE exported to environmental variables')
-        ABORT = True
+    try:
+	accounts = os.environ['AWS_PROFILE'].split(',')
+    except KeyError:
+	accounts = ['default']
 
 if args['<bucket_names>']:
     target_buckets = args['<bucket_names>']

--- a/s3-encryption/s3-bucket-inventory-policy.py
+++ b/s3-encryption/s3-bucket-inventory-policy.py
@@ -51,11 +51,10 @@ else:
 if args['--accounts']:
     accounts = args['--accounts'].split(',')
 else:
-    if 'AWS_PROFILE' in os.environ:
-        accounts = os.environ['AWS_PROFILE'].split(',')
-    else:
-        print('You did not specify --accounts and also do not have AWS_PROFILE exported to environmental variables')
-        ABORT = True
+    try:
+	accounts = os.environ['AWS_PROFILE'].split(',')
+    except KeyError:
+	accounts = ['default']
 
 if args['<bucket_names>']:
     target_buckets = args['<bucket_names>']

--- a/s3-encryption/s3-object-encryption-cleanup.py
+++ b/s3-encryption/s3-object-encryption-cleanup.py
@@ -74,11 +74,10 @@ else:
 if args['--accounts']:
     accounts = args['--accounts'].split(',')
 else:
-    if 'AWS_PROFILE' in os.environ:
-        accounts = os.environ['AWS_PROFILE'].split(',')
-    else:
-        print('You did not specify --accounts and also do not have AWS_PROFILE exported to environmental variables')
-        ABORT = True
+    try:
+	accounts = os.environ['AWS_PROFILE'].split(',')
+    except KeyError:
+	accounts = ['default']
 
 if args['--buckets'] is not None:
     target_buckets = args['--buckets'].split(',')


### PR DESCRIPTION
The tools currently refuse to run if the AWS_PROFILE environment variable is unset and the --accounts option is not given. After this patch, the 'default' account is used as a last resort.

Tested:
./s3-bucket-default-encryption.py audit